### PR TITLE
Adds error handling and schema validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 arrow==1.2.*
+cerberus==1.3.*
 dropbox==11.21.*
 requests==2.26.*
 sodapy==2.1.*


### PR DESCRIPTION
- https://github.com/cityofaustin/atd-data-tech/issues/11262

These changes:
1. Ensure that we always select a valid/not null `checkout_date` to use to determine if we should have new Dropbox data
2. Adds schema validation to enforce that null values are not allowed. That's the underlying problem that got us here.

Separately, I am deleting the ~17k records from Dec 2022 from the [Socrata dataset](https://data.austintexas.gov/Transportation-and-Mobility/Austin-MetroBike-Trips/tyfh-5r8s). That should be done in a few hours. Edit: it's done.

Once this branch is merged, the ETL is going to fail once a week until someone cleans up the Dropbox trip data and adds the checkout data/time values.


Steps to test:
Follow the steps in the readme to build the docker image, configure env vars, and run the `publish_trips.py` script.

You'll get the following console output
```shell
 publish_trips.py.INFO: Checking for Dropbox data at /austinbcycletripdata/2022/TripReport-122022.csv
 publish_trips.py.INFO: Transforming data...
 publish_trips.py.INFO: Validating data...
Traceback (most recent call last):
  File "publish_trips.py", line 172, in <module>
    main()
  File "publish_trips.py", line 165, in main
    [validate_row(row, validator) for row in data]
  File "publish_trips.py", line 165, in <listcomp>
    [validate_row(row, validator) for row in data]
  File "publish_trips.py", line 127, in validate_row
    raise ValueError(f"Schema validation error: {validator.errors}")
ValueError: Schema validation error: {'checkout_date': ['null value not allowed'], 'checkout_time': ['null value not allowed']}
```

The script will fail validation due to Dec 2022 trips having blank checkout date.