### PR TITLE
Bike Type based on ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ cython_debug/
 .DS_Store
 pytest.ini
 env_file
+.idea/

--- a/publish_trips.py
+++ b/publish_trips.py
@@ -4,13 +4,13 @@ Metrobike staff put new trip data in Dropbox share on a monthly basis.
 """
 import csv
 from datetime import datetime
-import dateutil.parser
-from dateutil.relativedelta import relativedelta
 import logging
 import os
 import sys
 
 from cerberus import Validator
+import dateutil.parser
+from dateutil.relativedelta import relativedelta
 import dropbox
 import requests
 from sodapy import Socrata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow==1.2.*
+python-dateutil==2.8.*
 cerberus==1.3.*
 dropbox==11.21.*
 requests==2.26.*


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/9388

Adding some logic to the MetroBike ETL fill in the Bike Type column with either electric or classic bikes based on the ID. From Hunter at CapMetro:

> All e-bikes will have 5 digit bike numbers starting with “15” and up.

I also did some refactoring of the code to use `dateutil` instead of `arrow` and added a function to populate those `year` and `month` columns in the [dataset](https://data.austintexas.gov/Transportation-and-Mobility/Austin-MetroBike-Trips/tyfh-5r8s/data).

As for testing, running this code will likely do nothing 99% of the time unless there is an unprocessed file in the dropbox from CapMetro. Commenting out lines 177, 178, and 183 in publish_trips.py will allow you to run this on the last month's data.  You can view the "Bike Type", "Year", and "Month" being populated in the Socrata dataset for the most recent few months. I'll have to re-process the full dataset in the future.