### PR TITLE
Datetime column, removing short trips, and historical data scripts

### DIFF
--- a/historical_data_processing/archive_processing_2013-2015.py
+++ b/historical_data_processing/archive_processing_2013-2015.py
@@ -1,0 +1,293 @@
+"""
+Script that processes historical data that does not meet the schema validation required in the newer data
+in publish_trips.py. Intended for data years 2016-2022.
+"""
+import csv
+import logging
+import os
+import sys
+
+import dateutil.parser
+
+import dropbox
+import requests
+from sodapy import Socrata
+
+import pandas as pd
+
+METROBIKE_DROPBOX_TOKEN = os.getenv("METROBIKE_DROPBOX_TOKEN")
+SOCRATA_API_KEY_ID = os.getenv("SOCRATA_API_KEY_ID")
+SOCRATA_API_KEY_SECRET = os.getenv("SOCRATA_API_KEY_SECRET")
+SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
+
+RESOURCE_ID = "tyfh-5r8s"
+
+FIELDS = {
+    "TripId": "trip_id",
+    "MembershipType": "membership_type",
+    "Bike": "bicycle_id",
+    "BikeType": "bike_type",
+    "CheckoutDateLocal": "checkout_date",
+    "CheckoutTimeLocal": "checkout_time",
+    "CheckoutKioskID": "checkout_kiosk_id",
+    "CheckoutKioskName": "checkout_kiosk",
+    "ReturnKioskID": "return_kiosk_id",
+    "ReturnKioskName": "return_kiosk",
+    "DurationMins": "trip_duration_minutes",
+}
+
+# for handling different column mappings
+BACKUP_FIELDS = {
+    "Trip ID": "trip_id",
+    "Membership Type": "membership_type",
+    "Bike": "bicycle_id",
+    "BikeType": "bike_type",
+    "Checkout Date": "checkout_date",
+    "Checkout Time": "checkout_time",
+    "Checkout Kiosk ID": "checkout_kiosk_id",
+    "Checkout Kiosk": "checkout_kiosk",
+    "Return Kiosk ID": "return_kiosk_id",
+    "Return Kiosk": "return_kiosk",
+    "Duration (Minutes)": "trip_duration_minutes",
+}
+
+# for handling more different column mappings
+BACKUP_FIELDS_V2 = {
+    "TripId": "trip_id",
+    "Membership Type": "membership_type",
+    "Bike": "bicycle_id",
+    "BikeType": "bike_type",
+    "Checkout Date": "checkout_date",
+    "Checkout Time": "checkout_time",
+    "Checkout Kiosk ID": "checkout_kiosk_id",
+    "Checkout Kiosk": "checkout_kiosk",
+    "Return Kiosk ID": "return_kiosk_id",
+    "Return Kiosk": "return_kiosk",
+    "Duration (Minutes)": "trip_duration_minutes",
+}
+
+# At minimum, required to have these columns
+req_columns = [
+    "trip_id",
+    "bicycle_id",
+    "checkout_date",
+    "checkout_time",
+    "trip_duration_minutes",
+]
+
+def getLogger(name, level=logging.INFO):
+    """Return a module logger that streams to stdout"""
+    logger = logging.getLogger(name)
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(fmt=" %(name)s.%(levelname)s: %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger
+
+
+def get_max_socrata_date(resource_id):
+    url = f"https://data.austintexas.gov/resource/{resource_id}.json"
+    params = {
+        "$query": "SELECT checkout_date as date where checkout_date is not null ORDER BY checkout_date DESC LIMIT 1"
+    }
+    res = requests.get(url, params=params)
+    res.raise_for_status()
+    try:
+        datestring = res.json()[0]["date"]
+    except (KeyError, IndexError):
+        raise ValueError(
+            "No existing data found. There may be something wrong with the dataset?"
+        )
+    return dateutil.parser.parse(datestring)
+
+
+def get_data(path, token):
+    """Get trip data file as string from dropbox"""
+    dbx = dropbox.Dropbox(token)
+
+    try:
+        metadata, res = dbx.files_download(path)
+
+    except dropbox.exceptions.ApiError:
+        #  file not found - we take that to mean the data has not been uploaded to Dropbox yet by Metrobike staff
+        logger.warning(f"No trip data file found at {path}")
+        return None
+    res.raise_for_status()
+    return res
+
+
+def handle_value(key, value, date_keys=["CheckoutDateLocal", "Checkout Date",]):
+    if value == "":
+        return None
+    if not value or key not in date_keys:
+        return value
+    # Format a socrata-friendly date
+    return dateutil.parser.parse(value).strftime("%Y-%m-%d")
+
+
+def map_row(row):
+    if "Trip ID" in row.keys():
+        mapping = BACKUP_FIELDS
+    elif "Checkout Date" in row.keys():
+        mapping = BACKUP_FIELDS_V2
+    else:
+        mapping = FIELDS
+    return {
+        mapping[key]: handle_value(key, value)
+        for key, value in row.items()
+        if key in mapping
+    }
+
+
+def classify_bike_type(data):
+    """
+    Classifying Bikes into Electric or Classic types based on the ID pattern supplied by CapMetro.
+    All e-bikes will have 5 digit bike numbers starting with “15” and up.
+    """
+    for row in data:
+        if len(row["bicycle_id"]) == 5 and int(row["bicycle_id"][0:2]) >= 15:
+            row["bike_type"] = "electric"
+        # Additional case where the ID is a six character ID with a trailing E are also E-bikes
+        elif (
+            len(row["bicycle_id"]) == 6
+            and int(row["bicycle_id"][0:2]) >= 15
+            and row["bicycle_id"][5] == "E"
+        ):
+            row["bike_type"] = "electric"
+        else:
+            row["bike_type"] = "classic"
+
+    return data
+
+
+def populate_month_year(data):
+    """
+    Extracts the month and year of the checkout date for two columns in the Socrata dataset
+    """
+    for row in data:
+        date = dateutil.parser.parse(row["checkout_date"])
+        row["year"] = date.strftime("%Y")
+        row["month"] = date.strftime("%-m")
+    return data
+
+
+def datetime_creation(data):
+    """
+    Joins together the checkout time and date columns to a single datetime field.
+    """
+    for row in data:
+        # Hour is not zero padded in the data so we have to check for that
+        if len(row["checkout_time"]) == 7:
+            row["checkout_datetime"] = f"{row['checkout_date']}T0{row['checkout_time']}"
+        else:
+            row["checkout_datetime"] = f"{row['checkout_date']}T{row['checkout_time']}"
+    return data
+
+
+def handle_data(csv_text):
+    """Parse CSV"""
+    rows = csv_text.splitlines()
+    reader = csv.DictReader(rows)
+    data = [map_row(row) for row in reader]
+    fields = list(data[0].keys())
+
+    for col in req_columns:
+        try:
+            assert col in fields
+        except:
+            print(reader.fieldnames)
+            raise
+
+    # Get bike type
+    data = classify_bike_type(data)
+    # Add month/year columns
+    data = populate_month_year(data)
+    # Add datetime column
+    data = datetime_creation(data)
+    # Remove trips that are less than 2 minutes in length
+    data = [d for d in data if int(d.get("trip_duration_minutes", 0)) > 1]
+    return data
+
+
+def handle_xls_data(data):
+    fields = list(data[0].keys())
+
+    for col in req_columns:
+        try:
+            assert col in fields
+        except:
+            print(fields)
+            raise
+
+    # Get bike type
+    data = classify_bike_type(data)
+    # Add month/year columns
+    data = populate_month_year(data)
+    # Add datetime column
+    data = datetime_creation(data)
+    # Remove trips that are less than 2 minutes in length
+    data = [d for d in data if d.get("trip_duration_minutes", 0) > 1]
+    return data
+
+def main():
+    client = Socrata(
+        "datahub.austintexas.gov",
+        SOCRATA_APP_TOKEN,
+        username=SOCRATA_API_KEY_ID,
+        password=SOCRATA_API_KEY_SECRET,
+        timeout=30,
+    )
+    dbx = dropbox.Dropbox(METROBIKE_DROPBOX_TOKEN)
+    year = 2022
+
+    while True:
+        files = dbx.files_list_folder(f"/austinbcycletripdata/{year}/").entries
+        for f in files:
+            current_file = f.name
+            root = "austinbcycletripdata"  # note the lowercase-ness
+            path = "/{}/{}/{}".format(root, year, current_file)
+
+            logger.info(f"Checking for Dropbox data at {path}")
+
+            csv_text = get_data(path, METROBIKE_DROPBOX_TOKEN)
+
+            # Handling Excel files with pandas
+            if f.name[-4:] == "xlsx":
+                xls_text = csv_text.content
+                data = pd.read_excel(xls_text)
+
+                # Schema detection
+                if "Trip ID" in data.columns:
+                    mapping = BACKUP_FIELDS
+                elif "Checkout Date" in data.columns:
+                    mapping = BACKUP_FIELDS_V2
+                else:
+                    mapping = FIELDS
+
+                data.rename(columns=mapping, inplace=True).drop(
+                    columns=[col for col in data.columns if col not in mapping]
+                )
+                data = data.to_dict("records")
+                data = handle_xls_data(data)
+                client.upsert(RESOURCE_ID, data)
+
+            # handling CSV files here:
+            else:
+
+                csv_text = csv_text.text
+                if not csv_text:
+                    return
+
+                logger.info(f"Transforming data...")
+                data = handle_data(csv_text)
+
+                logger.info(f"Uploading {len(data)} trips...")
+                client.upsert(RESOURCE_ID, data)
+
+        year -= 1
+
+
+if __name__ == "__main__":
+    logger = getLogger(__file__)
+    main()

--- a/historical_data_processing/archive_processing_2013-2015.py
+++ b/historical_data_processing/archive_processing_2013-2015.py
@@ -1,105 +1,49 @@
 """
-Script that processes historical data that does not meet the schema validation required in the newer data
-in publish_trips.py. Intended for data years 2016-2022.
+Script that publishes data to Socrata from a file that is stored on Dropbox that contains data for
+trips between December 2013 and January 2016. This file is in a different format with different column
+definitions so that's why this script needed to be created.
 """
-import csv
-import logging
-import os
-import sys
-
-import dateutil.parser
-
-import dropbox
-import requests
-from sodapy import Socrata
 
 import pandas as pd
+import dropbox
+import os
+from io import StringIO
+from pytz import timezone
+from sodapy import Socrata
+import numpy as np
+
+FIELDS = [
+    "trip_id",
+    "membership_type",
+    "bicycle_id",
+    "bike_type",
+    "checkout_date",
+    "checkout_time",
+    "checkout_datetime",
+    "checkout_kiosk_id",
+    "checkout_kiosk",
+    "return_kiosk_id",
+    "return_kiosk",
+    "trip_duration_minutes",
+    "month",
+    "year",
+]
 
 METROBIKE_DROPBOX_TOKEN = os.getenv("METROBIKE_DROPBOX_TOKEN")
 SOCRATA_API_KEY_ID = os.getenv("SOCRATA_API_KEY_ID")
 SOCRATA_API_KEY_SECRET = os.getenv("SOCRATA_API_KEY_SECRET")
 SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
-
 RESOURCE_ID = "tyfh-5r8s"
 
-FIELDS = {
-    "TripId": "trip_id",
-    "MembershipType": "membership_type",
-    "Bike": "bicycle_id",
-    "BikeType": "bike_type",
-    "CheckoutDateLocal": "checkout_date",
-    "CheckoutTimeLocal": "checkout_time",
-    "CheckoutKioskID": "checkout_kiosk_id",
-    "CheckoutKioskName": "checkout_kiosk",
-    "ReturnKioskID": "return_kiosk_id",
-    "ReturnKioskName": "return_kiosk",
-    "DurationMins": "trip_duration_minutes",
-}
+client = Socrata(
+    "datahub.austintexas.gov",
+    SOCRATA_APP_TOKEN,
+    username=SOCRATA_API_KEY_ID,
+    password=SOCRATA_API_KEY_SECRET,
+    timeout=60,
+)
 
-# for handling different column mappings
-BACKUP_FIELDS = {
-    "Trip ID": "trip_id",
-    "Membership Type": "membership_type",
-    "Bike": "bicycle_id",
-    "BikeType": "bike_type",
-    "Checkout Date": "checkout_date",
-    "Checkout Time": "checkout_time",
-    "Checkout Kiosk ID": "checkout_kiosk_id",
-    "Checkout Kiosk": "checkout_kiosk",
-    "Return Kiosk ID": "return_kiosk_id",
-    "Return Kiosk": "return_kiosk",
-    "Duration (Minutes)": "trip_duration_minutes",
-}
-
-# for handling more different column mappings
-BACKUP_FIELDS_V2 = {
-    "TripId": "trip_id",
-    "Membership Type": "membership_type",
-    "Bike": "bicycle_id",
-    "BikeType": "bike_type",
-    "Checkout Date": "checkout_date",
-    "Checkout Time": "checkout_time",
-    "Checkout Kiosk ID": "checkout_kiosk_id",
-    "Checkout Kiosk": "checkout_kiosk",
-    "Return Kiosk ID": "return_kiosk_id",
-    "Return Kiosk": "return_kiosk",
-    "Duration (Minutes)": "trip_duration_minutes",
-}
-
-# At minimum, required to have these columns
-req_columns = [
-    "trip_id",
-    "bicycle_id",
-    "checkout_date",
-    "checkout_time",
-    "trip_duration_minutes",
-]
-
-def getLogger(name, level=logging.INFO):
-    """Return a module logger that streams to stdout"""
-    logger = logging.getLogger(name)
-    handler = logging.StreamHandler(stream=sys.stdout)
-    formatter = logging.Formatter(fmt=" %(name)s.%(levelname)s: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(level)
-    return logger
-
-
-def get_max_socrata_date(resource_id):
-    url = f"https://data.austintexas.gov/resource/{resource_id}.json"
-    params = {
-        "$query": "SELECT checkout_date as date where checkout_date is not null ORDER BY checkout_date DESC LIMIT 1"
-    }
-    res = requests.get(url, params=params)
-    res.raise_for_status()
-    try:
-        datestring = res.json()[0]["date"]
-    except (KeyError, IndexError):
-        raise ValueError(
-            "No existing data found. There may be something wrong with the dataset?"
-        )
-    return dateutil.parser.parse(datestring)
+dbx = dropbox.Dropbox(METROBIKE_DROPBOX_TOKEN)
 
 
 def get_data(path, token):
@@ -111,183 +55,175 @@ def get_data(path, token):
 
     except dropbox.exceptions.ApiError:
         #  file not found - we take that to mean the data has not been uploaded to Dropbox yet by Metrobike staff
-        logger.warning(f"No trip data file found at {path}")
+        # logger.warning(f"No trip data file found at {path}")
         return None
     res.raise_for_status()
     return res
 
 
-def handle_value(key, value, date_keys=["CheckoutDateLocal", "Checkout Date",]):
-    if value == "":
-        return None
-    if not value or key not in date_keys:
-        return value
-    # Format a socrata-friendly date
-    return dateutil.parser.parse(value).strftime("%Y-%m-%d")
+# Downloading CSV from dropbox
+data = get_data(
+    "/austinbcycletripdata/AustinTripQuery_pre2018.csv", METROBIKE_DROPBOX_TOKEN
+)
+df = pd.read_csv(StringIO(data.text))
+
+# Mapping for columns that are already in the right format
+column_mapping = {
+    "TripId": "trip_id",
+    "MembershipType": "membership_type",
+    "BikeVisibleId": "bicycle_id",
+    "Duration": "trip_duration_minutes",
+}
+df.rename(columns=column_mapping, inplace=True)
+
+# Filtering out maintenance trips and short trips
+df = df[df["trip_duration_minutes"] > 1]
+df = df[df["ActualCharge"] >= 0]
+
+# Date/time fields
+central_timezone = timezone("US/Central")
+
+df["RentalDate CST"] = pd.to_datetime(df["RentalDate CST"].str[:-7])
+df["RentalDate CST"] = (
+    df["RentalDate CST"].dt.tz_localize("utc").dt.tz_convert(central_timezone)
+)
+df["checkout_date"] = df["RentalDate CST"].dt.strftime("%Y-%m-%d")
+df["checkout_time"] = df["RentalDate CST"].dt.strftime("%-H:%M:%S")
+df["checkout_datetime"] = df["RentalDate CST"].dt.strftime("%Y-%m-%dT%H:%M:%S")
+df["year"] = df["RentalDate CST"].dt.strftime("%Y")
+df["month"] = df["RentalDate CST"].dt.strftime("%-m")
+df["hour"] = df["RentalDate CST"].dt.strftime("%H")
+
+# Kiosk IDs lookup city asset number value in another table
+kiosks = pd.read_csv("https://data.austintexas.gov/resource/qd73-bsdg.csv")
+
+# Adding in some missing kiosk IDs into the dataset
+kiosks.loc[kiosks["kiosk_id"] == 2550, "city_asset_num"] = 2550
+kiosks.loc[kiosks["kiosk_id"] == 2576, "city_asset_num"] = 2576
+kiosks.loc[kiosks["kiosk_id"] == 2564, "city_asset_num"] = 2564
+kiosks.loc[kiosks["kiosk_id"] == 2536, "city_asset_num"] = 2536
+kiosks.loc[kiosks["kiosk_id"] == 3381, "city_asset_num"] = 3381
+kiosks.loc[kiosks["kiosk_id"] == 2546, "city_asset_num"] = 2546
+kiosks.loc[kiosks["kiosk_id"] == 2545, "city_asset_num"] = 2545
+kiosks.loc[kiosks["kiosk_id"] == 2712, "city_asset_num"] = 6
+kiosks.loc[kiosks["kiosk_id"] == 1006, "city_asset_num"] = 1006
+kiosks.loc[kiosks["kiosk_id"] == 2500, "city_asset_num"] = 2500
+
+# Create lookup table between city_asset_num used by the CSV and kiosk_ids we use in the dataset
+kiosks = kiosks[kiosks["city_asset_num"] >= 0]
+kiosks["city_asset_num"] = kiosks["city_asset_num"].astype("Int32")
+kiosks = kiosks[["kiosk_id", "city_asset_num"]]
+
+# Cleaning up some kiosk IDs
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].astype(str)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].astype(str)
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].str.replace(" UT", "")
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].str.replace(" UT", "")
+
+df["CheckoutKioskOptionalId"] = (
+    df["CheckoutKioskOptionalId"].astype(float).astype("Int32")
+)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].astype(float).astype("Int32")
+
+# fixing several IDs manually...
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].replace(2, 16742)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].replace(2, 16742)
+
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].replace(32517, 16729)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].replace(32517, 16729)
+
+df.loc[
+    df["CheckoutKiosk"] == "Republic Square @ Guadalupe & 4th St.",
+    "CheckoutKioskOptionalId",
+] = 2550
+df.loc[
+    df["ReturnKiosk"] == "Republic Square @ Guadalupe & 4th St.",
+    "ReturnKioskOptionalId",
+] = 2550
+
+df.loc[df["CheckoutKiosk"] == "Rainey @ River St", "CheckoutKioskOptionalId"] = 2576
+df.loc[df["ReturnKiosk"] == "Rainey @ River St", "ReturnKioskOptionalId"] = 2576
+
+df.loc[df["CheckoutKiosk"] == "5th & San Marcos", "CheckoutKioskOptionalId"] = 2564
+df.loc[df["ReturnKiosk"] == "5th & San Marcos", "ReturnKioskOptionalId"] = 2564
+
+df.loc[
+    df["CheckoutKiosk"] == "East 7th & Pleasant Valley", "CheckoutKioskOptionalId"
+] = 3381
+df.loc[
+    df["ReturnKiosk"] == "East 7th & Pleasant Valley", "ReturnKioskOptionalId"
+] = 3381
+
+df.loc[df["CheckoutKiosk"] == "Waller & 6th St.", "CheckoutKioskOptionalId"] = 2536
+df.loc[df["ReturnKiosk"] == "Waller & 6th St.", "ReturnKioskOptionalId"] = 2536
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - West & 12th Street", "CheckoutKioskOptionalId"
+] = 2546
+df.loc[df["ReturnKiosk"] == "ACC - West & 12th Street", "ReturnKioskOptionalId"] = 2546
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - Rio Grande & 12th", "CheckoutKioskOptionalId"
+] = 2545
+df.loc[df["ReturnKiosk"] == "ACC - Rio Grande & 12th", "ReturnKioskOptionalId"] = 2545
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - Rio Grande & 12th", "CheckoutKioskOptionalId"
+] = 2545
+df.loc[df["ReturnKiosk"] == "ACC - Rio Grande & 12th", "ReturnKioskOptionalId"] = 2545
+
+df.loc[df["CheckoutKiosk"] == "Zilker Park West", "CheckoutKioskOptionalId"] = 1006
+df.loc[df["ReturnKiosk"] == "Zilker Park West", "ReturnKioskOptionalId"] = 1006
+
+df.loc[df["CheckoutKiosk"] == "Republic Square ", "CheckoutKioskOptionalId"] = 2500
+df.loc[df["ReturnKiosk"] == "Republic Square ", "ReturnKioskOptionalId"] = 2500
+
+# Join in data from the lookup table to get kiosk IDs for return and checkout kiosks
+df = df.merge(
+    kiosks, left_on="CheckoutKioskOptionalId", right_on="city_asset_num", how="left"
+)
+
+df.rename(
+    columns={"kiosk_id": "checkout_kiosk_id", "CheckoutKiosk": "checkout_kiosk"},
+    inplace=True,
+)
+df = df.merge(
+    kiosks, left_on="ReturnKioskOptionalId", right_on="city_asset_num", how="left"
+)
+df.rename(
+    columns={"kiosk_id": "return_kiosk_id", "ReturnKiosk": "return_kiosk"}, inplace=True
+)
+
+# Socrata expects text field for kiosk IDs, so drop any trailing zeroes
+df["return_kiosk_id"] = df["return_kiosk_id"].astype(str).replace("\.0", "", regex=True)
+df["checkout_kiosk_id"] = (
+    df["checkout_kiosk_id"].astype(str).replace("\.0", "", regex=True)
+)
+
+# all bikes are classic in pre-2016 data
+df["bike_type"] = "classic"
+
+# Verify we have all the correct columns
+for field in FIELDS:
+    assert field in df.columns
+df = df[FIELDS]
 
 
-def map_row(row):
-    if "Trip ID" in row.keys():
-        mapping = BACKUP_FIELDS
-    elif "Checkout Date" in row.keys():
-        mapping = BACKUP_FIELDS_V2
-    else:
-        mapping = FIELDS
-    return {
-        mapping[key]: handle_value(key, value)
-        for key, value in row.items()
-        if key in mapping
-    }
-
-
-def classify_bike_type(data):
-    """
-    Classifying Bikes into Electric or Classic types based on the ID pattern supplied by CapMetro.
-    All e-bikes will have 5 digit bike numbers starting with “15” and up.
-    """
-    for row in data:
-        if len(row["bicycle_id"]) == 5 and int(row["bicycle_id"][0:2]) >= 15:
-            row["bike_type"] = "electric"
-        # Additional case where the ID is a six character ID with a trailing E are also E-bikes
-        elif (
-            len(row["bicycle_id"]) == 6
-            and int(row["bicycle_id"][0:2]) >= 15
-            and row["bicycle_id"][5] == "E"
-        ):
-            row["bike_type"] = "electric"
-        else:
-            row["bike_type"] = "classic"
-
-    return data
-
-
-def populate_month_year(data):
-    """
-    Extracts the month and year of the checkout date for two columns in the Socrata dataset
-    """
-    for row in data:
-        date = dateutil.parser.parse(row["checkout_date"])
-        row["year"] = date.strftime("%Y")
-        row["month"] = date.strftime("%-m")
-    return data
-
-
-def datetime_creation(data):
-    """
-    Joins together the checkout time and date columns to a single datetime field.
-    """
-    for row in data:
-        # Hour is not zero padded in the data so we have to check for that
-        if len(row["checkout_time"]) == 7:
-            row["checkout_datetime"] = f"{row['checkout_date']}T0{row['checkout_time']}"
-        else:
-            row["checkout_datetime"] = f"{row['checkout_date']}T{row['checkout_time']}"
-    return data
-
-
-def handle_data(csv_text):
-    """Parse CSV"""
-    rows = csv_text.splitlines()
-    reader = csv.DictReader(rows)
-    data = [map_row(row) for row in reader]
-    fields = list(data[0].keys())
-
-    for col in req_columns:
+def df_to_socrata(soda, df, dataset_id, include_index):
+    if include_index:
+        df = df.reset_index()
+    df = df.replace({np.nan: None})
+    payload = df.to_dict(orient="records")
+    num = 0
+    while payload:
+        n = 10000
+        batch, payload = payload[:n], payload[n:]
+        print(f"uploading batch: {num}")
+        num += 1
         try:
-            assert col in fields
-        except:
-            print(reader.fieldnames)
-            raise
+            res = soda.upsert(dataset_id, batch)
+        except Exception as e:
+            raise e
 
-    # Get bike type
-    data = classify_bike_type(data)
-    # Add month/year columns
-    data = populate_month_year(data)
-    # Add datetime column
-    data = datetime_creation(data)
-    # Remove trips that are less than 2 minutes in length
-    data = [d for d in data if int(d.get("trip_duration_minutes", 0)) > 1]
-    return data
-
-
-def handle_xls_data(data):
-    fields = list(data[0].keys())
-
-    for col in req_columns:
-        try:
-            assert col in fields
-        except:
-            print(fields)
-            raise
-
-    # Get bike type
-    data = classify_bike_type(data)
-    # Add month/year columns
-    data = populate_month_year(data)
-    # Add datetime column
-    data = datetime_creation(data)
-    # Remove trips that are less than 2 minutes in length
-    data = [d for d in data if d.get("trip_duration_minutes", 0) > 1]
-    return data
-
-def main():
-    client = Socrata(
-        "datahub.austintexas.gov",
-        SOCRATA_APP_TOKEN,
-        username=SOCRATA_API_KEY_ID,
-        password=SOCRATA_API_KEY_SECRET,
-        timeout=30,
-    )
-    dbx = dropbox.Dropbox(METROBIKE_DROPBOX_TOKEN)
-    year = 2022
-
-    while True:
-        files = dbx.files_list_folder(f"/austinbcycletripdata/{year}/").entries
-        for f in files:
-            current_file = f.name
-            root = "austinbcycletripdata"  # note the lowercase-ness
-            path = "/{}/{}/{}".format(root, year, current_file)
-
-            logger.info(f"Checking for Dropbox data at {path}")
-
-            csv_text = get_data(path, METROBIKE_DROPBOX_TOKEN)
-
-            # Handling Excel files with pandas
-            if f.name[-4:] == "xlsx":
-                xls_text = csv_text.content
-                data = pd.read_excel(xls_text)
-
-                # Schema detection
-                if "Trip ID" in data.columns:
-                    mapping = BACKUP_FIELDS
-                elif "Checkout Date" in data.columns:
-                    mapping = BACKUP_FIELDS_V2
-                else:
-                    mapping = FIELDS
-
-                data.rename(columns=mapping, inplace=True).drop(
-                    columns=[col for col in data.columns if col not in mapping]
-                )
-                data = data.to_dict("records")
-                data = handle_xls_data(data)
-                client.upsert(RESOURCE_ID, data)
-
-            # handling CSV files here:
-            else:
-
-                csv_text = csv_text.text
-                if not csv_text:
-                    return
-
-                logger.info(f"Transforming data...")
-                data = handle_data(csv_text)
-
-                logger.info(f"Uploading {len(data)} trips...")
-                client.upsert(RESOURCE_ID, data)
-
-        year -= 1
-
-
-if __name__ == "__main__":
-    logger = getLogger(__file__)
-    main()
+# Upsert data to socrata
+df_to_socrata(client, df, RESOURCE_ID, False)

--- a/historical_data_processing/archive_processing_2016-2022.py
+++ b/historical_data_processing/archive_processing_2016-2022.py
@@ -1,0 +1,229 @@
+"""
+Script that publishes data to Socrata from a file that is stored on Dropbox that contains data for
+trips between December 2013 and January 2016. This file is in a different format with different column
+definitions so that's why this script needed to be created.
+"""
+
+import pandas as pd
+import dropbox
+import os
+from io import StringIO
+from pytz import timezone
+from sodapy import Socrata
+import numpy as np
+
+FIELDS = [
+    "trip_id",
+    "membership_type",
+    "bicycle_id",
+    "bike_type",
+    "checkout_date",
+    "checkout_time",
+    "checkout_datetime",
+    "checkout_kiosk_id",
+    "checkout_kiosk",
+    "return_kiosk_id",
+    "return_kiosk",
+    "trip_duration_minutes",
+    "month",
+    "year",
+]
+
+METROBIKE_DROPBOX_TOKEN = os.getenv("METROBIKE_DROPBOX_TOKEN")
+SOCRATA_API_KEY_ID = os.getenv("SOCRATA_API_KEY_ID")
+SOCRATA_API_KEY_SECRET = os.getenv("SOCRATA_API_KEY_SECRET")
+SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
+RESOURCE_ID = "tyfh-5r8s"
+
+client = Socrata(
+    "datahub.austintexas.gov",
+    SOCRATA_APP_TOKEN,
+    username=SOCRATA_API_KEY_ID,
+    password=SOCRATA_API_KEY_SECRET,
+    timeout=60,
+)
+
+dbx = dropbox.Dropbox(METROBIKE_DROPBOX_TOKEN)
+
+
+def get_data(path, token):
+    """Get trip data file as string from dropbox"""
+    dbx = dropbox.Dropbox(token)
+
+    try:
+        metadata, res = dbx.files_download(path)
+
+    except dropbox.exceptions.ApiError:
+        #  file not found - we take that to mean the data has not been uploaded to Dropbox yet by Metrobike staff
+        # logger.warning(f"No trip data file found at {path}")
+        return None
+    res.raise_for_status()
+    return res
+
+
+# Downloading CSV from dropbox
+data = get_data(
+    "/austinbcycletripdata/AustinTripQuery_pre2018.csv", METROBIKE_DROPBOX_TOKEN
+)
+df = pd.read_csv(StringIO(data.text))
+
+# Mapping for columns that are already in the right format
+column_mapping = {
+    "TripId": "trip_id",
+    "MembershipType": "membership_type",
+    "BikeVisibleId": "bicycle_id",
+    "Duration": "trip_duration_minutes",
+}
+df.rename(columns=column_mapping, inplace=True)
+
+# Filtering out maintenance trips and short trips
+df = df[df["trip_duration_minutes"] > 1]
+df = df[df["ActualCharge"] >= 0]
+
+# Date/time fields
+central_timezone = timezone("US/Central")
+
+df["RentalDate CST"] = pd.to_datetime(df["RentalDate CST"].str[:-7])
+df["RentalDate CST"] = (
+    df["RentalDate CST"].dt.tz_localize("utc").dt.tz_convert(central_timezone)
+)
+df["checkout_date"] = df["RentalDate CST"].dt.strftime("%Y-%m-%d")
+df["checkout_time"] = df["RentalDate CST"].dt.strftime("%-H:%M:%S")
+df["checkout_datetime"] = df["RentalDate CST"].dt.strftime("%Y-%m-%dT%H:%M:%S")
+df["year"] = df["RentalDate CST"].dt.strftime("%Y")
+df["month"] = df["RentalDate CST"].dt.strftime("%-m")
+df["hour"] = df["RentalDate CST"].dt.strftime("%H")
+
+# Kiosk IDs lookup city asset number value in another table
+kiosks = pd.read_csv("https://data.austintexas.gov/resource/qd73-bsdg.csv")
+
+# Adding in some missing kiosk IDs into the dataset
+kiosks.loc[kiosks["kiosk_id"] == 2550, "city_asset_num"] = 2550
+kiosks.loc[kiosks["kiosk_id"] == 2576, "city_asset_num"] = 2576
+kiosks.loc[kiosks["kiosk_id"] == 2564, "city_asset_num"] = 2564
+kiosks.loc[kiosks["kiosk_id"] == 2536, "city_asset_num"] = 2536
+kiosks.loc[kiosks["kiosk_id"] == 3381, "city_asset_num"] = 3381
+kiosks.loc[kiosks["kiosk_id"] == 2546, "city_asset_num"] = 2546
+kiosks.loc[kiosks["kiosk_id"] == 2545, "city_asset_num"] = 2545
+kiosks.loc[kiosks["kiosk_id"] == 2712, "city_asset_num"] = 6
+kiosks.loc[kiosks["kiosk_id"] == 1006, "city_asset_num"] = 1006
+kiosks.loc[kiosks["kiosk_id"] == 2500, "city_asset_num"] = 2500
+
+# Create lookup table between city_asset_num used by the CSV and kiosk_ids we use in the dataset
+kiosks = kiosks[kiosks["city_asset_num"] >= 0]
+kiosks["city_asset_num"] = kiosks["city_asset_num"].astype("Int32")
+kiosks = kiosks[["kiosk_id", "city_asset_num"]]
+
+# Cleaning up some kiosk IDs
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].astype(str)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].astype(str)
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].str.replace(" UT", "")
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].str.replace(" UT", "")
+
+df["CheckoutKioskOptionalId"] = (
+    df["CheckoutKioskOptionalId"].astype(float).astype("Int32")
+)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].astype(float).astype("Int32")
+
+# fixing several IDs manually...
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].replace(2, 16742)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].replace(2, 16742)
+
+df["CheckoutKioskOptionalId"] = df["CheckoutKioskOptionalId"].replace(32517, 16729)
+df["ReturnKioskOptionalId"] = df["ReturnKioskOptionalId"].replace(32517, 16729)
+
+df.loc[
+    df["CheckoutKiosk"] == "Republic Square @ Guadalupe & 4th St.",
+    "CheckoutKioskOptionalId",
+] = 2550
+df.loc[
+    df["ReturnKiosk"] == "Republic Square @ Guadalupe & 4th St.",
+    "ReturnKioskOptionalId",
+] = 2550
+
+df.loc[df["CheckoutKiosk"] == "Rainey @ River St", "CheckoutKioskOptionalId"] = 2576
+df.loc[df["ReturnKiosk"] == "Rainey @ River St", "ReturnKioskOptionalId"] = 2576
+
+df.loc[df["CheckoutKiosk"] == "5th & San Marcos", "CheckoutKioskOptionalId"] = 2564
+df.loc[df["ReturnKiosk"] == "5th & San Marcos", "ReturnKioskOptionalId"] = 2564
+
+df.loc[
+    df["CheckoutKiosk"] == "East 7th & Pleasant Valley", "CheckoutKioskOptionalId"
+] = 3381
+df.loc[
+    df["ReturnKiosk"] == "East 7th & Pleasant Valley", "ReturnKioskOptionalId"
+] = 3381
+
+df.loc[df["CheckoutKiosk"] == "Waller & 6th St.", "CheckoutKioskOptionalId"] = 2536
+df.loc[df["ReturnKiosk"] == "Waller & 6th St.", "ReturnKioskOptionalId"] = 2536
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - West & 12th Street", "CheckoutKioskOptionalId"
+] = 2546
+df.loc[df["ReturnKiosk"] == "ACC - West & 12th Street", "ReturnKioskOptionalId"] = 2546
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - Rio Grande & 12th", "CheckoutKioskOptionalId"
+] = 2545
+df.loc[df["ReturnKiosk"] == "ACC - Rio Grande & 12th", "ReturnKioskOptionalId"] = 2545
+
+df.loc[
+    df["CheckoutKiosk"] == "ACC - Rio Grande & 12th", "CheckoutKioskOptionalId"
+] = 2545
+df.loc[df["ReturnKiosk"] == "ACC - Rio Grande & 12th", "ReturnKioskOptionalId"] = 2545
+
+df.loc[df["CheckoutKiosk"] == "Zilker Park West", "CheckoutKioskOptionalId"] = 1006
+df.loc[df["ReturnKiosk"] == "Zilker Park West", "ReturnKioskOptionalId"] = 1006
+
+df.loc[df["CheckoutKiosk"] == "Republic Square ", "CheckoutKioskOptionalId"] = 2500
+df.loc[df["ReturnKiosk"] == "Republic Square ", "ReturnKioskOptionalId"] = 2500
+
+# Join in data from the lookup table to get kiosk IDs for return and checkout kiosks
+df = df.merge(
+    kiosks, left_on="CheckoutKioskOptionalId", right_on="city_asset_num", how="left"
+)
+
+df.rename(
+    columns={"kiosk_id": "checkout_kiosk_id", "CheckoutKiosk": "checkout_kiosk"},
+    inplace=True,
+)
+df = df.merge(
+    kiosks, left_on="ReturnKioskOptionalId", right_on="city_asset_num", how="left"
+)
+df.rename(
+    columns={"kiosk_id": "return_kiosk_id", "ReturnKiosk": "return_kiosk"}, inplace=True
+)
+
+# Socrata expects text field for kiosk IDs, so drop any trailing zeroes
+df["return_kiosk_id"] = df["return_kiosk_id"].astype(str).replace("\.0", "", regex=True)
+df["checkout_kiosk_id"] = (
+    df["checkout_kiosk_id"].astype(str).replace("\.0", "", regex=True)
+)
+
+# all bikes are classic in pre-2016 data
+df["bike_type"] = "classic"
+
+# Verify we have all the correct columns
+for field in FIELDS:
+    assert field in df.columns
+df = df[FIELDS]
+
+
+def df_to_socrata(soda, df, dataset_id, include_index):
+    if include_index:
+        df = df.reset_index()
+    df = df.replace({np.nan: None})
+    payload = df.to_dict(orient="records")
+    num = 0
+    while payload:
+        n = 10000
+        batch, payload = payload[:n], payload[n:]
+        print(f"uploading batch: {num}")
+        num += 1
+        try:
+            res = soda.upsert(dataset_id, batch)
+        except Exception as e:
+            raise e
+
+# Upsert data to socrata
+df_to_socrata(client, df, RESOURCE_ID, False)

--- a/publish_trips.py
+++ b/publish_trips.py
@@ -47,6 +47,7 @@ SCHEMA = {
     "bicycle_id": {"type": "string"},
     "checkout_date": {"type": "string"},
     "checkout_time": {"type": "string"},
+    "checkout_datetime": {"type": "string"},
     "checkout_kiosk_id": {"type": "string"},
     "checkout_kiosk": {"type": "string"},
     "return_kiosk_id": {"type": "string"},
@@ -151,6 +152,18 @@ def populate_month_year(data):
         row["month"] = date.strftime("%-m")
     return data
 
+def datetime_creation(data):
+    """
+    Joins together the checkout time and date columns to a single datetime field.
+    """
+    for row in data:
+        # Hour is not zero padded in the data so we have to check for that
+        if len(row["checkout_time"]) == 7:
+            row["checkout_datetime"] = f"{row['checkout_date']}T0{row['checkout_time']}"
+        else:
+            row["checkout_datetime"] = f"{row['checkout_date']}T{row['checkout_time']}"
+    return data
+
 
 def handle_data(csv_text):
     """Parse CSV"""
@@ -161,6 +174,10 @@ def handle_data(csv_text):
     data = classify_bike_type(data)
     # Add month/year columns
     data = populate_month_year(data)
+    # Add datetime column
+    data = datetime_creation(data)
+    # Remove trips that are less than 2 minutes in length
+    data = [d for d in data if int(d.get("trip_duration_minutes", 0)) > 1]
     return data
 
 

--- a/publish_trips.py
+++ b/publish_trips.py
@@ -157,11 +157,8 @@ def datetime_creation(data):
     Joins together the checkout time and date columns to a single datetime field.
     """
     for row in data:
-        # Hour is not zero padded in the data so we have to check for that
-        if len(row["checkout_time"]) == 7:
-            row["checkout_datetime"] = f"{row['checkout_date']}T0{row['checkout_time']}"
-        else:
-            row["checkout_datetime"] = f"{row['checkout_date']}T{row['checkout_time']}"
+        # Note that hour is not zero padded in the data
+        row["checkout_datetime"] = f"{row['checkout_date']}T{row['checkout_time'].zfill(8)}"
     return data
 
 
@@ -171,11 +168,11 @@ def handle_data(csv_text):
     reader = csv.DictReader(rows)
     data = [map_row(row) for row in reader]
     # Get bike type
-    data = classify_bike_type(data)
+    classify_bike_type(data)
     # Add month/year columns
-    data = populate_month_year(data)
+    populate_month_year(data)
     # Add datetime column
-    data = datetime_creation(data)
+    datetime_creation(data)
     # Remove trips that are less than 2 minutes in length
     data = [d for d in data if int(d.get("trip_duration_minutes", 0)) > 1]
     return data


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/12705

Improvements to the [dataset](https://data.austintexas.gov/Transportation-and-Mobility/Austin-MetroBike-Trips/tyfh-5r8s/data):
- Reprocessed all historical data to populate `bike_type` column. So now all trips are either `electric` or `classic` (human) powered trips.
- Added a `checkout_datetime` column that combines the `checkout_date` and `checkout_time` (those remain in the dataset for backwards compatibility) columns so it is much easier to query dates and times together. `checkout_time` was just a text field so it was difficult to query with that.
- I've deleted all trips under 2 minutes in length. Hunter (CapMetro) has been removing these trips himself recently but I noticed we had a bunch in the historical data that I've removed, and I've enforced that we ignore those records with a trip duration of less than 2 minutes going forward.

This PR also contains two scripts I used to re-process the archive of MetroBike data. 
- `archive_processing_2013-2015.py` handles data that was provided to us by MetroBike corporate that has some significant differences with the regular export from MetroBike we have at other time periods. This new file had to be created in our previous archive of data did not contain a `trip_id` column so it much harder to update things and remove errors in our data. 
- `archive_processing_2016-2022.py` is similar to our current production ETL but ignores the field schema validation John implemented to the main ETL since these files have nulls where it was previously acceptable to have null fields.
- I do use pandas in these ☝️ but I don't believe we need to include that in `requirements.txt` since these files should be run locally anyway and not needed to be included with any of our MetroBike data pipelines. Maybe a separate `requirements.txt` just for that directory?

Some things to address in the future:
- Cleaning up the kiosks [dataset](https://data.austintexas.gov/Transportation-and-Mobility/Austin-MetroBike-Kiosk-Locations/qd73-bsdg/data) and validate the kiosk IDs in our trips dataset has a matching kiosk.
- I noticed in the corporate MetroBike dataset, that there is a trip distance field. This is GPS distance the trip took so that may be interesting to include. 